### PR TITLE
Use pycryptodomex instead of pycryptodome (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.16.3
+- [MODULE] Replaced `pycryptodome` with `pycryptodomex`
+- [MODULE] Removed `pbkdf2` dependency
+### 0.16.2
+- [MODULE] Added bsd support
+### 0.16.1
+- [MODULE] Fix resource warning about unclosed file
+- [FIREFOX] Added firefox snap directory
 ### 0.16.0
 - [MODULE] Added new browser support: Safari
 ### 0.15.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='browser-cookie3',
-    version='0.16.0',
+    version='0.16.3',
     packages=['browser_cookie3'],
     # look for package contents in current directory
     package_dir={'browser_cookie3': '.'},
@@ -10,6 +10,6 @@ setup(
     author_email='boris.ivan.babic@gmail.com',
     description='Loads cookies from your browser into a cookiejar object so can download with urllib and other libraries the same content you see in the web browser.',
     url='https://github.com/borisbabic/browser_cookie3',
-    install_requires=['pyaes', 'pbkdf2', 'keyring', 'lz4', 'pycryptodome', 'SecretStorage'],
+    install_requires=['keyring', 'lz4', 'pycryptodomex', 'SecretStorage'],
     license='lgpl'
 )


### PR DESCRIPTION
* Use pycryptodomex instead of pycryptodome

* Rearrange imports

* Replace pyaes with pycryptodomex

* fixed pyaes to pycryptodomex migration

Co-authored-by: Ibrahim Rafi <rafiibrahim8@hotmail.com>